### PR TITLE
Move paket reference resolution to it's file

### DIFF
--- a/src/fsharp/CompileOps.fsi
+++ b/src/fsharp/CompileOps.fsi
@@ -799,6 +799,3 @@ type LoadClosure =
 
     /// Used from fsi.fs and fsc.fs, for #load and command line. The resulting references are then added to a TcConfig.
     static member ComputeClosureOfSourceFiles : CompilationThreadToken * tcConfig:TcConfig * (string * range) list * implicitDefines:CodeContext * lexResourceManager : Lexhelp.LexResourceManager -> LoadClosure
-
-module ScriptPreprocessClosure = 
-    val ResolvePackages : implicitIncludeDIr: string * scriptName: string * packageManagerText: string list * range -> string option

--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -422,6 +422,9 @@
     <Compile Include="..\IlxGen.fs">
       <Link>IlxGen.fs</Link>
     </Compile>
+    <Compile Include="..\ReferenceLoading.PaketHandler.fs">
+      <Link>Driver\ReferenceLoading.PaketHandler.fs</Link>
+    </Compile>
     <Compile Include="..\CompileOps.fsi">
       <Link>CompileOps.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
+++ b/src/fsharp/FSharp.Compiler/FSharp.Compiler.fsproj
@@ -471,6 +471,9 @@
     <Compile Include="..\IlxGen.fs">
       <Link>CodeGen\IlxGen.fs</Link>
     </Compile>
+    <Compile Include="..\ReferenceLoading.PaketHandler.fs">
+      <Link>Driver\ReferenceLoading.PaketHandler.fs</Link>
+    </Compile>
     <Compile Include="..\CompileOps.fsi">
       <Link>Driver\CompileOps.fsi</Link>
     </Compile>

--- a/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
+++ b/src/fsharp/FSharp.LanguageService.Compiler/FSharp.LanguageService.Compiler.fsproj
@@ -475,6 +475,9 @@
     <Compile Include="..\IlxGen.fs">
       <Link>CodeGen/IlxGen.fs</Link>
     </Compile>
+    <Compile Include="..\ReferenceLoading.PaketHandler.fs">
+      <Link>Driver\ReferenceLoading.PaketHandler.fs</Link>
+    </Compile>
     <Compile Include="..\CompileOps.fsi">
       <Link>Driver\CompileOps.fsi</Link>
     </Compile>

--- a/src/fsharp/ReferenceLoading.PaketHandler.fs
+++ b/src/fsharp/ReferenceLoading.PaketHandler.fs
@@ -1,0 +1,144 @@
+module ReferenceLoading.PaketHandler
+
+type ReferenceLoadingResult =
+| Solved of loadingScript: string
+| PackageManagerNotFound of implicitIncludeDir: string * userProfile: string
+| PackageResolutionFailed of toolPath: string * workingDir: string * msg : string
+
+module Internals =
+    open System
+    open System.IO
+    let PM_EXE = "paket.exe"
+    let PM_DIR = ".paket"
+    let PM_SPEC_FILE = "paket.dependencies"
+    let PM_LOCK_FILE = "paket.lock"
+    let PM_COMMAND = "install --generate-load-scripts"
+    let PM_LOADSCRIPT = PM_DIR + "/load/main.group.fsx"
+
+    let userProfile = 
+        let res = Environment.GetEnvironmentVariable("USERPROFILE")
+        if System.String.IsNullOrEmpty res then
+            Environment.GetEnvironmentVariable("HOME")
+        else res
+
+    let getDiretoryAndAllParentDirectories (directory: DirectoryInfo) =
+        let rec allParents (directory: DirectoryInfo) =
+            seq {
+                match directory.Parent with
+                | null -> ()
+                | parent -> 
+                    yield parent
+                    yield! allParents parent
+            }
+
+        seq {
+            yield directory
+            yield! allParents directory
+        }
+
+    let findPaketExe (baseDir: string) =
+        let getPaketAndExe (directory: DirectoryInfo) =
+            let dir = directory.GetDirectories(PM_DIR)
+            match dir with
+            | [|dir|] -> 
+              match dir.GetFiles(PM_EXE) with
+              | [|exe|] -> Some exe.FullName
+              | _ -> None
+            | _ -> None
+
+        let dir = DirectoryInfo baseDir
+        let allDirs = getDiretoryAndAllParentDirectories dir
+        
+        allDirs
+        |> Seq.choose getPaketAndExe
+        |> Seq.tryHead
+
+    let ResolvePackages (implicitIncludeDir: string, scriptName: string, packageManagerTextLines: string list) =
+        printfn "OBJ %A" (implicitIncludeDir,scriptName)
+        let workingDir = Path.Combine(Path.GetTempPath(),"fsx-packages", string(abs(hash (implicitIncludeDir,scriptName))))
+        let workingDirSpecFile = FileInfo(Path.Combine(workingDir,PM_SPEC_FILE))
+        if not (Directory.Exists workingDir) then
+            Directory.CreateDirectory workingDir |> ignore
+
+        let packageManagerTextLines = packageManagerTextLines |> List.filter (fun l -> not (String.IsNullOrWhiteSpace l))
+
+        let rootDir,packageManagerTextLines =
+            let rec findSpecFile dir =
+                let fi = FileInfo(Path.Combine(dir,PM_SPEC_FILE))
+                if fi.Exists then
+                    let lockFile = FileInfo(Path.Combine(fi.Directory.FullName,PM_LOCK_FILE))
+                    let depsFileLines = File.ReadAllLines fi.FullName
+                    if lockFile.Exists then
+                        let originalDepsFile = FileInfo(workingDirSpecFile.FullName + ".original")
+                        if not originalDepsFile.Exists ||
+                           File.ReadAllLines originalDepsFile.FullName <> depsFileLines
+                        then
+                            File.Copy(fi.FullName,originalDepsFile.FullName,true)
+                            let targetLockFile = FileInfo(Path.Combine(workingDir,PM_LOCK_FILE))
+                            File.Copy(lockFile.FullName,targetLockFile.FullName,true)
+                        
+                    fi.Directory.FullName, (Array.toList depsFileLines) @ packageManagerTextLines
+                elif fi.Directory.Parent <> null then
+                    findSpecFile fi.Directory.Parent.FullName
+                else
+                    workingDir, "framework: net461" :: "source https://nuget.org/api/v2" :: packageManagerTextLines
+           
+            findSpecFile implicitIncludeDir
+
+        let toolPathOpt = 
+            match findPaketExe implicitIncludeDir with
+            | Some paketExe -> Some paketExe
+            | None ->
+                match findPaketExe rootDir with
+                | Some paketExe -> Some paketExe
+                | None ->
+                  let profileExe = Path.Combine (userProfile, PM_DIR, PM_EXE)
+                  if File.Exists profileExe then Some profileExe
+                  else None
+
+        match toolPathOpt with 
+        | None -> 
+            PackageManagerNotFound(implicitIncludeDir, userProfile)
+
+        | Some toolPath ->
+            let loadScript = Path.Combine(workingDir,PM_LOADSCRIPT)
+            if workingDirSpecFile.Exists && 
+               (File.ReadAllLines(workingDirSpecFile.FullName) |> Array.toList) = packageManagerTextLines && 
+               File.Exists loadScript
+            then 
+                printfn "skipping running package resolution... already done that" 
+                Solved loadScript
+            else
+                try File.Delete(loadScript) with _ -> ()
+                let toolPath = if Microsoft.FSharp.Compiler.AbstractIL.IL.runningOnMono then "mono " + toolPath else toolPath
+                File.WriteAllLines(workingDirSpecFile.FullName, packageManagerTextLines)
+                printfn "running package resolution in '%s'..." workingDir
+                let startInfo = 
+                    System.Diagnostics.ProcessStartInfo(
+                        FileName = toolPath,
+                        WorkingDirectory = workingDir, 
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        Arguments = PM_COMMAND,
+                        CreateNoWindow = true,
+                        UseShellExecute = false)
+                
+                use p = new System.Diagnostics.Process()
+                let errors = System.Collections.Generic.List<_>()
+                let log = System.Collections.Generic.List<_>()
+                p.StartInfo <- startInfo
+                p.ErrorDataReceived.Add(fun d -> if d.Data <> null then errors.Add d.Data)
+                p.OutputDataReceived.Add(fun d -> if d.Data <> null then log.Add d.Data)
+                p.Start() |> ignore
+                p.BeginErrorReadLine()
+                p.BeginOutputReadLine()
+                p.WaitForExit()
+
+                printfn "done running package resolution..."
+                if p.ExitCode <> 0 then
+                    let msg = String.Join(Environment.NewLine, errors)
+                    PackageResolutionFailed(toolPath, workingDir, msg)
+                else
+                    printfn "package resolution completed at %A" System.DateTimeOffset.UtcNow
+                    Solved loadScript
+

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -1234,9 +1234,12 @@ type internal FsiDynamicCompiler
     member fsiDynamicCompiler.CommitPackageManagerText (ctok, istate: FsiDynamicCompilerState, lexResourceManager, errorLogger, m) = 
         if not needsPackageResolution then istate else
         needsPackageResolution <- false
-        match ScriptPreprocessClosure.ResolvePackages (tcConfigB.implicitIncludeDir, "stdin.fsx", tcConfigB.packageManagerTextLines, m) with
-        | Some loadScript -> fsiDynamicCompiler.EvalSourceFiles (ctok, istate, m, [loadScript], lexResourceManager, errorLogger)
-        | None -> istate
+        match ReferenceLoading.PaketHandler.Internals.ResolvePackages (tcConfigB.implicitIncludeDir, "stdin.fsx", tcConfigB.packageManagerTextLines) with
+        | ReferenceLoading.PaketHandler.ReferenceLoadingResult.Solved loadScript -> 
+            fsiDynamicCompiler.EvalSourceFiles (ctok, istate, m, [loadScript], lexResourceManager, errorLogger)
+        | ReferenceLoading.PaketHandler.ReferenceLoadingResult.PackageManagerNotFound (_)
+        | ReferenceLoading.PaketHandler.ReferenceLoadingResult.PackageResolutionFailed (_) ->
+            istate
 
     member fsiDynamicCompiler.ProcessMetaCommandsFromInputAsInteractiveCommands(ctok, istate, sourceFile, inp) =
         WithImplicitHome


### PR DESCRIPTION
it still works on my machine, but it fails if there is a paket.dependencies with groups (it appends the nuget to last group), or if .paket/paket.exe is found but older pre 4.xxx version 

What I did:

* defined a DU for Solved / and errors cases
* remove dependency from FSC codebase in ResolvePackage method
* changed the walk up and find .paket/paket.exe implementation to not loop