### PR TITLE
Failing test with groups

### DIFF
--- a/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/paket.dependencies
+++ b/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/paket.dependencies
@@ -1,0 +1,6 @@
+framework: net461
+source https://nuget.org/api/v2
+
+group Test
+    source https://nuget.org/api/v2
+    nuget NUnit

--- a/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/paket.lock
+++ b/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/paket.lock
@@ -1,0 +1,7 @@
+FRAMEWORK: NET461
+NUGET
+  remote: https://www.nuget.org/api/v2
+    FSharp.Data (2.3.2)
+    Newtonsoft.Json (9.0.1)
+    XPlot.Plotly (1.4.2)
+      Newtonsoft.Json (9.0.1)

--- a/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/plot.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Paket/PaketWithDepsCanHaveGroups/plot.fsx
@@ -1,0 +1,5 @@
+#r "paket: nuget XPlot.Plotly"
+
+open XPlot.Plotly
+
+Chart.Line [ 1 .. 10 ]

--- a/tests/fsharpqa/Source/InteractiveSession/Paket/env.lst
+++ b/tests/fsharpqa/Source/InteractiveSession/Paket/env.lst
@@ -2,6 +2,7 @@
 	SOURCE="SimplePaketTestTrim\\plot.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# simple direct deps, with missing space in directive
 	SOURCE="SimplePaketFailTest\\plot.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# non-existent package
 	SOURCE="PaketWithDepsFile\\plot.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# with deps file
+	SOURCE="PaketWithDepsCanHaveGroups\\plot.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# with deps file with groups (appending to groups may kill the source)
 	SOURCE="PaketWithBrokenDepsFile\\plot.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# with broken deps file
 	SOURCE="PaketWithRemoteFile\\UseGlobbing.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# use paket remote file
 	SOURCE="PaketWithLocalSources\\script1.fsx"   COMPILE_ONLY=1 FSIMODE=FEED SCFLAGS="--nologo"	# with local nupgk


### PR DESCRIPTION
add a failing test, when paket.dependencies has groups, the source defined at the top won't be valid in "group Main" being generated