### PR TITLE
Update Program.fs

### DIFF
--- a/fcs/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
+++ b/fcs/FSharp.Compiler.Service.ProjectCrackerTool/Program.fs
@@ -34,7 +34,7 @@ module Program =
             ser.WriteObject(Console.OpenStandardOutput(), opts)
         ret
 
-
+    [<System.STAThread>]
     [<EntryPoint>]
     let main argv =
         let asText = Array.exists (fun (s: string) -> s = "--text") argv


### PR DESCRIPTION
Should fix: 

```
06:17:11 2) Failed : FSharp.Compiler.Service.Tests.ProjectOptionsTests.Project file parsing -- Logging
06:17:11   Expected: String containing "Microsoft.Build.Tasks.Core"
06:17:11   But was:  "The MSBuild engine must be called on a single-threaded-apartment. Current threading model is "MTA". Proceeding, but some tasks may not function correctly.
```