### PR TITLE
test condition update

### DIFF
--- a/tests/service/ExprTests.fs
+++ b/tests/service/ExprTests.fs
@@ -528,7 +528,7 @@ let bool2 = false
     let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
 
 //<@ let x = Some(3) in x.IsSome @>
-#if !NO_EXTENSIONTYPING || DOTNETCORE
+#if !NO_EXTENSIONTYPING
 [<Test>]
 let ``Test Declarations project1`` () =
     let wholeProjectResults = exprChecker.ParseAndCheckProject(Project1.options) |> Async.RunSynchronously


### PR DESCRIPTION
The previous commit makes the test pass in compiler, but fail in the compiler service (which was passing before). It's either-or, as they seem to be producing slightly different outputs (could be a missing flag or conditional, or something else).

This will revert to the original test condition (effectively disabling it in the service until dotnet core tests get support for EXTENSIONTYPING), as it was before.